### PR TITLE
Harre/check for exe

### DIFF
--- a/.idea/.idea.OpenCiv1/.idea/.gitignore
+++ b/.idea/.idea.OpenCiv1/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/projectSettingsUpdater.xml
+/.idea.OpenCiv1.iml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.OpenCiv1/.idea/encodings.xml
+++ b/.idea/.idea.OpenCiv1/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.OpenCiv1/.idea/indexLayout.xml
+++ b/.idea/.idea.OpenCiv1/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.OpenCiv1/.idea/vcs.xml
+++ b/.idea/.idea.OpenCiv1/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/OpenCiv1.cs
+++ b/OpenCiv1.cs
@@ -318,7 +318,13 @@ namespace OpenCiv1
 
 			this.oCPU.DS.Word = 0x3b01;
 
-			string sPath = $"{this.oCPU.DefaultDirectory}CIV.EXE";
+			var sPath = Path.Combine(oCPU.DefaultDirectory, "CIV.EXE");
+
+			if (!File.Exists(sPath))
+			{
+				throw new Exception($"CIV.EXE not found at {sPath}");
+			}
+			
 			this.oCPU.Memory.WriteUInt8(this.oCPU.DS.Word, 0x61ee, (byte)Path.GetPathRoot(this.oCPU.DefaultDirectory)[0]);
 			this.oCPU.WriteString(CPU.ToLinearAddress(this.oCPU.DS.Word, 0x6156), sPath, sPath.Length);
 


### PR DESCRIPTION
The program should check for existance of CIV.EXE before going further as any future errors are quite unclear to debug.

Also a good idea is to use Path.Combine so you don't need to care for the path separator on linux or windows.