### PR TITLE
Files on DOS are always uppercase

### DIFF
--- a/API/MSCAPI.cs
+++ b/API/MSCAPI.cs
@@ -318,7 +318,7 @@ namespace OpenCiv1
 			}
 
 			short sHandle = -1;
-			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(filename).ToLower());
+			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(filename).ToUpper());
 			this.oCPU.Log.WriteLine($"Opening file '{sPath}', with file handle {this.oCPU.FileHandleCount}");
 
 			try
@@ -685,7 +685,7 @@ namespace OpenCiv1
 			}
 
 			short sHandle = -1;
-			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(filename).ToLower());
+			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(filename).ToUpper());
 
 			this.oCPU.Log.WriteLine($"Opening file '{sPath}', with file handle {this.oCPU.FileHandleCount}");
 			try
@@ -839,7 +839,7 @@ namespace OpenCiv1
 				eMode = FileMode.Open;
 			}
 
-			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(sName).ToLower());
+			string sPath = Path.Combine(this.oCPU.DefaultDirectory, Path.GetFileName(sName).ToUpper());
 			if (File.Exists(sPath))
 			{
 				this.oCPU.Log.WriteLine($"Opening file '{sPath}', with file handle {this.oCPU.FileHandleCount}");

--- a/CPU/CPU.cs
+++ b/CPU/CPU.cs
@@ -70,7 +70,6 @@ namespace IRB.VirtualCPU
 			this.oMemory = new CPUMemory(this);
 			this.oTimer = new System.Threading.Timer(oTimer_Tick, null, 25, 25);
 
-#if DEBUG
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				this.sDefaultDirectory = Path.Combine("C:" + Path.DirectorySeparatorChar, "Dos", "Civ1") + Path.DirectorySeparatorChar;
@@ -79,9 +78,6 @@ namespace IRB.VirtualCPU
 			{
 				this.sDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Dos", "Civ1") + Path.DirectorySeparatorChar;
 			}
-#else
-			this.DefaultDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Path.DirectorySeparatorChar;
-#endif
 		}
 
 		public OpenCiv1.OpenCiv1 Parent
@@ -2070,7 +2066,7 @@ namespace IRB.VirtualCPU
 		{
 			if (this.oAX.Low == 3)
 			{
-				string sName = Path.GetFileName(this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word))).ToLower();
+				string sName = Path.GetFileName(this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word))).ToUpper();
 				string sPath = Path.Combine(this.sDefaultDirectory, sName);
 				ushort usSegment = ReadUInt16(this.oES.Word, this.oBX.Word);
 				ushort usRelocationSegment = ReadUInt16(this.oES.Word, (ushort)(this.oBX.Word + 2));
@@ -2225,7 +2221,7 @@ namespace IRB.VirtualCPU
 		private void DOSCreateFileUsingHandle()
 		{
 			// open file
-			string sName = Path.GetFileName(this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word))).ToLower();
+			string sName = Path.GetFileName(this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word))).ToUpper();
 			string sPath = Path.Combine(this.sDefaultDirectory, sName);
 			FileAccess access = FileAccess.ReadWrite;
 
@@ -2330,7 +2326,7 @@ namespace IRB.VirtualCPU
 		private void DOSOpenFileUsingHandle()
 		{
 			// open file
-			string sName = this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word)).ToLower();
+			string sName = this.ReadString(CPU.ToLinearAddress(this.DS.Word, this.DX.Word)).ToUpper();
 			string sPath = Path.Combine(this.sDefaultDirectory, sName);
 			FileAccess access = FileAccess.Read;
 
@@ -2532,7 +2528,7 @@ namespace IRB.VirtualCPU
 			string sFilename = this.ReadString(CPU.ToLinearAddress(this.oDS.Word, this.oSI.Word));
 			string sName = Path.GetFileNameWithoutExtension(sFilename);
 			string sExtension = Path.GetExtension(sFilename).Substring(1);
-			string sPath = Path.Combine(this.sDefaultDirectory, sFilename.ToLower());
+			string sPath = Path.Combine(this.sDefaultDirectory, sFilename.ToUpper());
 
 			if (File.Exists(sPath))
 			{
@@ -2554,7 +2550,7 @@ namespace IRB.VirtualCPU
 		{
 			DOS_FCB fcb = new DOS_FCB(this.oMemory, this.oDS.Word, this.oDX.Word);
 			string sFileName = fcb.GetName();
-			string sPath = Path.Combine(this.sDefaultDirectory, sFileName.ToLower());
+			string sPath = Path.Combine(this.sDefaultDirectory, sFileName.ToUpper());
 
 			if (File.Exists(sPath))
 			{

--- a/OpenCiv1.cs
+++ b/OpenCiv1.cs
@@ -197,26 +197,26 @@ namespace OpenCiv1
 			}
 
 			string[] aResourceFiles = new string[] {
-				"adscreen.pic", "arch.pic", "back0a.pic", "back0m.pic", "back1a.pic", "back1m.pic", "back2a.pic", "back2m.pic", 
-				"back3a.pic", "birth0.pic", "birth1.pic", "birth2.pic", "birth3.pic", "birth4.pic", "birth5.pic", "birth6.pic", 
-				"birth7.pic", "birth8.pic", "castle0.pic", "castle1.pic", "castle2.pic", "castle3.pic", "castle4.pic", "cback.pic", 
-				"cbacks1.pic", "cbacks2.pic", "cbacks3.pic", "cbrush0.pic", "cbrush1.pic", "cbrush2.pic", "cbrush3.pic", 
-				"cbrush4.pic", "cbrush5.pic", "citypix1.pic", "citypix2.pic", "citypix3.pic", "custom.pic", "diffs.pic", 
-				"discovr1.pic", "discovr2.pic", "docker.pic", "govt0a.pic", "govt0m.pic", "govt1a.pic", "govt1m.pic", "govt2a.pic", 
-				"govt2m.pic", "govt3a.pic", "hill.pic", "iconpg1.pic", "iconpg2.pic", "iconpg3.pic", "iconpg4.pic", "iconpg5.pic", 
-				"iconpg6.pic", "iconpg7.pic", "iconpg8.pic", "iconpga.pic", "iconpgb.pic", "iconpgc.pic", "iconpgd.pic", 
-				"iconpge.pic", "iconpgt1.pic", "iconpgt2.pic", "invader2.pic", "invader3.pic", "invaders.pic", "king00.pic", 
-				"king01.pic", "king02.pic", "king03.pic", "king04.pic", "king05.pic", "king06.pic", "king07.pic", "king08.pic", 
-				"king09.pic", "king10.pic", "king11.pic", "king12.pic", "king13.pic", "kink00.pic", "kink03.pic", "logo.pic", 
-				"love1.pic", "love2.pic", "map.pic", "nuke1.pic", "planet1.pic", "planet2.pic", "pop.pic", "riot.pic", "riot2.pic", 
-				"sad.pic", "settlers.pic", "slag2.pic", "slam1.pic", "slam2.pic", "sp257.pic", "sp299.pic", "spacest.pic", 
-				"sprites.pic", "ter257.pic", "torch.pic", "wonders.pic", "wonders2.pic", "back0a.pal", "back0m.pal", "back1a.pal", 
-				"back1m.pal", "back2a.pal", "back2m.pal", "back3a.pal", "birth0.pal", "birth1.pal", "birth2.pal", "birth3.pal", 
-				"birth4.pal", "birth5.pal", "birth6.pal", "birth7.pal", "birth8.pal", "discovr1.pal", "discovr2.pal", "hill.pal", 
-				"iconpg1.pal", "iconpga.pal", "king00.pal", "king01.pal", "king02.pal", "king03.pal", "king04.pal", "king05.pal", 
-				"king06.pal", "king07.pal", "king08.pal", "king09.pal", "king10.pal", "king11.pal", "king12.pal", "king13.pal", 
-				"slam1.pal", "sp256.pal", "sp257.pal", "blurb0.txt", "blurb1.txt", "blurb2.txt", "blurb3.txt", "blurb4.txt", 
-				"credits.txt", "error.txt", "help.txt", "intro.txt", "intro3.txt", "king.txt", "produce.txt", "story.txt"
+				"ADSCREEN.PIC", "ARCH.PIC", "BACK0A.PIC", "BACK0M.PIC", "BACK1A.PIC", "BACK1M.PIC", "BACK2A.PIC", "BACK2M.PIC", 
+				"BACK3A.PIC", "BIRTH0.PIC", "BIRTH1.PIC", "BIRTH2.PIC", "BIRTH3.PIC", "BIRTH4.PIC", "BIRTH5.PIC", "BIRTH6.PIC", 
+				"BIRTH7.PIC", "BIRTH8.PIC", "CASTLE0.PIC", "CASTLE1.PIC", "CASTLE2.PIC", "CASTLE3.PIC", "CASTLE4.PIC", "CBACK.PIC", 
+				"CBACKS1.PIC", "CBACKS2.PIC", "CBACKS3.PIC", "CBRUSH0.PIC", "CBRUSH1.PIC", "CBRUSH2.PIC", "CBRUSH3.PIC", 
+				"CBRUSH4.PIC", "CBRUSH5.PIC", "CITYPIX1.PIC", "CITYPIX2.PIC", "CITYPIX3.PIC", "CUSTOM.PIC", "DIFFS.PIC", 
+				"DISCOVR1.PIC", "DISCOVR2.PIC", "DOCKER.PIC", "GOVT0A.PIC", "GOVT0M.PIC", "GOVT1A.PIC", "GOVT1M.PIC", "GOVT2A.PIC", 
+				"GOVT2M.PIC", "GOVT3A.PIC", "HILL.PIC", "ICONPG1.PIC", "ICONPG2.PIC", "ICONPG3.PIC", "ICONPG4.PIC", "ICONPG5.PIC", 
+				"ICONPG6.PIC", "ICONPG7.PIC", "ICONPG8.PIC", "ICONPGA.PIC", "ICONPGB.PIC", "ICONPGC.PIC", "ICONPGD.PIC", 
+				"ICONPGE.PIC", "ICONPGT1.PIC", "ICONPGT2.PIC", "INVADER2.PIC", "INVADER3.PIC", "INVADERS.PIC", "KING00.PIC", 
+				"KING01.PIC", "KING02.PIC", "KING03.PIC", "KING04.PIC", "KING05.PIC", "KING06.PIC", "KING07.PIC", "KING08.PIC", 
+				"KING09.PIC", "KING10.PIC", "KING11.PIC", "KING12.PIC", "KING13.PIC", "KINK00.PIC", "KINK03.PIC", "LOGO.PIC", 
+				"LOVE1.PIC", "LOVE2.PIC", "MAP.PIC", "NUKE1.PIC", "PLANET1.PIC", "PLANET2.PIC", "POP.PIC", "RIOT.PIC", "RIOT2.PIC", 
+				"SAD.PIC", "SETTLERS.PIC", "SLAG2.PIC", "SLAM1.PIC", "SLAM2.PIC", "SP257.PIC", "SP299.PIC", "SPACEST.PIC", 
+				"SPRITES.PIC", "TER257.PIC", "TORCH.PIC", "WONDERS.PIC", "WONDERS2.PIC", "BACK0A.PAL", "BACK0M.PAL", "BACK1A.PAL", 
+				"BACK1M.PAL", "BACK2A.PAL", "BACK2M.PAL", "BACK3A.PAL", "BIRTH0.PAL", "BIRTH1.PAL", "BIRTH2.PAL", "BIRTH3.PAL", 
+				"BIRTH4.PAL", "BIRTH5.PAL", "BIRTH6.PAL", "BIRTH7.PAL", "BIRTH8.PAL", "DISCOVR1.PAL", "DISCOVR2.PAL", "HILL.PAL", 
+				"ICONPG1.PAL", "ICONPGA.PAL", "KING00.PAL", "KING01.PAL", "KING02.PAL", "KING03.PAL", "KING04.PAL", "KING05.PAL", 
+				"KING06.PAL", "KING07.PAL", "KING08.PAL", "KING09.PAL", "KING10.PAL", "KING11.PAL", "KING12.PAL", "KING13.PAL", 
+				"SLAM1.PAL", "SP256.PAL", "SP257.PAL", "BLURB0.TXT", "BLURB1.TXT", "BLURB2.TXT", "BLURB3.TXT", "BLURB4.TXT", 
+				"CREDITS.TXT", "ERROR.TXT", "HELP.TXT", "INTRO.TXT", "INTRO3.TXT", "KING.TXT", "PRODUCE.TXT", "STORY.TXT"
 			};
 
 			for (int i = 0; i < aResourceFiles.Length; i++)

--- a/Segments/GameLoadAndSave.cs
+++ b/Segments/GameLoadAndSave.cs
@@ -923,7 +923,7 @@ namespace OpenCiv1
 
 			// function body
 			bool bSuccess = false;
-			string filename = Path.GetFileNameWithoutExtension(path).ToLower();
+			string filename = Path.GetFileNameWithoutExtension(path).ToUpper();
 
 			try
 			{

--- a/Segments/ImageTools.cs
+++ b/Segments/ImageTools.cs
@@ -22,7 +22,7 @@ namespace OpenCiv1
 		public void F0_2fa1_01a2_LoadBitmapOrPalette(short screenID, ushort xPos, ushort yPos, ushort filenamePtr, ushort palettePtr)
 		{
 			string filename = this.oCPU.DefaultDirectory +
-				Path.GetFileName(this.oCPU.ReadString(CPU.ToLinearAddress(this.oCPU.DS.Word, filenamePtr)));
+				Path.GetFileName(this.oCPU.ReadString(CPU.ToLinearAddress(this.oCPU.DS.Word, filenamePtr)).ToUpper());
 			this.oCPU.Log.EnterBlock($"F0_2fa1_01a2_LoadBitmapOrPalette(0x{screenID:x4}, 0x{xPos:x4}, 0x{yPos:x4}, " +
 				$"'{filename}', 0x{palettePtr:x4})");
 

--- a/Segments/Segment_1000.cs
+++ b/Segments/Segment_1000.cs
@@ -941,7 +941,7 @@ namespace OpenCiv1
 
 		public void F0_1000_066a_FileExists(ushort fileNamePtr)
 		{
-			string fileName = Path.GetFileName(this.oParent.CPU.ReadString(CPU.ToLinearAddress(this.oParent.CPU.DS.Word, fileNamePtr)));
+			string fileName = Path.GetFileName(this.oParent.CPU.ReadString(CPU.ToLinearAddress(this.oParent.CPU.DS.Word, fileNamePtr)).ToUpper());
 
 			this.oCPU.Log.EnterBlock($"F0_1000_066a_IsFileExists('{fileName}')");
 


### PR DESCRIPTION
I finally had time to get the latest code after your refactor and try it out.

I have made all files uppercase instead as linux seems to treat all files in DOS-isos in uppercase.

It seems that by definition in FAT the files were written always in uppercase.
https://superuser.com/a/862283/727703

With this change I'm able to run the game in Mono on Arch Linux.

I found this that you can try to test out case sensitivity on NTFS on windows:
https://superuser.com/a/1329066/727703

Also, it seems that when first turn is done I get an IndexOutOfRangeException:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
  at OpenCiv1.Segment_1d12.F0_1d12_0045 () [0x4b9e8] in /home/markus/code/OpenCiv1/Segments/Segment_1d12.cs:10916 
  at OpenCiv1.Segment_1ade.F0_1ade_0006 () [0x00509] in /home/markus/code/OpenCiv1/Segments/Segment_1ade.cs:63 
  at OpenCiv1.Segment_1238.F0_1238_0092 () [0x00c37] in /home/markus/code/OpenCiv1/Segments/Segment_1238.cs:240 
  at OpenCiv1.Segment_11a8.F0_11a8_0008_Main () [0x00d77] in /home/markus/code/OpenCiv1/Segments/Segment_11a8.cs:203 
  at OpenCiv1.OpenCiv1.Start () [0x018f3] in /home/markus/code/OpenCiv1/OpenCiv1.cs:380 
  at OpenCiv1.MainForm.GameThread () [0x00032] in /home/markus/code/OpenCiv1/MainForm.cs:589 
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /build/mono/src/mono/mcs/class/referencesource/mscorlib/system/threading/thread.cs:74 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /build/mono/src/mono/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:968 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /build/mono/src/mono/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:910 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /build/mono/src/mono/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:899 
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /build/mono/src/mono/mcs/class/referencesource/mscorlib/system/threading/thread.cs:111 
```
[logs.zip](https://github.com/rajko-horvat/OpenCiv1/files/13302839/logs.zip)


I'm not sure if that's related to my changes or not.