### PR TITLE
Consider nullable warnings as errors

### DIFF
--- a/OpenCiv1.csproj
+++ b/OpenCiv1.csproj
@@ -18,6 +18,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
     <Authors>Rajko Horvat</Authors>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds <WarningsAsErrors>nullable</WarningsAsErrors> to OpenCiv1.csproj